### PR TITLE
fix: resume scanning after result

### DIFF
--- a/BlinkID/ios/Classes/MicroblinkScannerView.swift
+++ b/BlinkID/ios/Classes/MicroblinkScannerView.swift
@@ -186,6 +186,7 @@ class CustomOverlayViewController : MBCustomOverlayViewController,
             DispatchQueue.main.async(execute: {() -> Void in
                 let results = self.recognizerCollection.recognizerList.map({ return $0.serializeResult() })
                 self.delegate?.onFinishScanning(results: results)
+                recognizerRunnerViewController.resumeScanningAndResetState(true)
             })
         }
     }

--- a/BlinkID/ios/Classes/MicroblinkScannerView.swift
+++ b/BlinkID/ios/Classes/MicroblinkScannerView.swift
@@ -108,6 +108,8 @@ class MicroblinkScannerView: NSObject,
         
         MBOverlaySerializationUtils.extractCommonOverlaySettings(jsonSettings, overlaySettings: settings)
         
+        settings.cameraSettings.cameraPreset = MBCameraPreset.presetPhoto
+        
         let overlayViewController = CustomOverlayViewController.init(recognizerCollection: self.recognizerCollection!,
                                                                      cameraSettings: settings.cameraSettings)
         overlayViewController.delegate = self


### PR DESCRIPTION
### Description
Sometimes Microblink sends an empty result on `onResult` callback. (all fields are empty). This can happen when we scan an unsupported document (OR a passport with the MRZ section covered). On Kiosk side, we handle this by returning a null result but unfortunately on the native iOS side, we pause any other scans. 

This PR fixes this by resuming the scan after the result was given and also reseting the state.

Additionally, the full camera resolution has been unlocked.