### PR TITLE
feat: bump version

### DIFF
--- a/BlinkID/android/build.gradle
+++ b/BlinkID/android/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     implementation "androidx.lifecycle:lifecycle-livedata:2.4.1"
 
-    def camerax_version = "1.1.0-beta02"
+    def camerax_version = "1.2.0"
     implementation "androidx.camera:camera-core:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"


### PR DESCRIPTION
Camera package was crashing with an invalid value given to the `surfaceRotationToRotationDegrees` method from `TransformUtils.java`. Bumping to a stable version seems to have fixed it.