### PR TITLE
fix: [RND-175929] Fix unnecessary scan requests on Android

### DIFF
--- a/BlinkID/android/src/main/java/com/microblink/flutter/MicroblinkScanner.java
+++ b/BlinkID/android/src/main/java/com/microblink/flutter/MicroblinkScanner.java
@@ -70,12 +70,16 @@ public class MicroblinkScanner implements ImageAnalysis.Analyzer {
                     JSONArray resultJsonArray =
                             RecognizerSerializers.INSTANCE.serializeRecognizerResults(
                                     recognizerBundle.getRecognizers());
-                    callbacks.onScanned(resultJsonArray.toString());
+                    callbacks.onScanned(resultJsonArray.toString(), new Callbacks.Callback() {
+                        @Override
+                        public void onResumeScanning() {
+                            imageProxy.close();
+                        }
+                    });
                 } else {
                     recognizerRunner.resetRecognitionState();
+                    imageProxy.close();
                 }
-
-                imageProxy.close();
             }
 
             @Override
@@ -157,11 +161,15 @@ public class MicroblinkScanner implements ImageAnalysis.Analyzer {
     }
 
     interface Callbacks {
+        interface Callback {
+            void onResumeScanning();
+        }
+
         void onFirstSideScanned();
 
         void onDetectionStatusUpdated(DetectionStatus detectionStatus);
 
-        void onScanned(String result);
+        void onScanned(String result, Callback callback);
 
         void onError(Throwable throwable);
     }


### PR DESCRIPTION
[RND-175929](https://mews.myjetbrains.com/youtrack/issue/RND-175929/Unnecessary-Microblink-scan-requests-on-Android)

This PR ensures that Android side of the plugin does not trigger more scanning attempts once we have a successful result.

This is a breaking change for the client. If you would like to test it locally for our Kiosk app, try this diff (mind that you might need to update the path to `blinkid-flutter/BlinkID` to match your setup):

<details>
<summary>diff for kiosk</summary>

```diff
diff --git a/kiosk/lib/src/session/presentation/microblink_document_scanner/microblink_document_scanner_widget_wrapper.dart b/kiosk/lib/src/session/presentation/microblink_document_scanner/microblink_document_scanner_widget_wrapper.dart
index f0746274a..cb1a3009e 100644
--- a/kiosk/lib/src/session/presentation/microblink_document_scanner/microblink_document_scanner_widget_wrapper.dart
+++ b/kiosk/lib/src/session/presentation/microblink_document_scanner/microblink_document_scanner_widget_wrapper.dart
@@ -15,7 +15,7 @@ class MicroblinkDocumentScannerWidgetWrapper extends StatelessWidget {
     required this.onDetectionStatusUpdate,
   }) : super(key: key);
 
-  final ValueSetter<List<RecognizerResult>?> onResult;
+  final MicroblinkScannerResultCallback onResult;
   final VoidCallback onFirstSideScanned;
   final ValueSetter<DetectionStatus> onDetectionStatusUpdate;
 
diff --git a/kiosk/lib/src/session/presentation/microblink_document_scanner/notification_based_microblink_scanner.dart b/kiosk/lib/src/session/presentation/microblink_document_scanner/notification_based_microblink_scanner.dart
index b2b346203..f3f851701 100644
--- a/kiosk/lib/src/session/presentation/microblink_document_scanner/notification_based_microblink_scanner.dart
+++ b/kiosk/lib/src/session/presentation/microblink_document_scanner/notification_based_microblink_scanner.dart
@@ -2,7 +2,6 @@ import 'package:blinkid_flutter/microblink_scanner.dart';
 import 'package:core/bloc.dart';
 import 'package:core/collections.dart';
 import 'package:core/connector_api.dart';
-import 'package:core/core.dart';
 import 'package:flutter/widgets.dart' hide Notification;
 import 'package:kiosk/src/analytics/analytics_event.dart';
 import 'package:kiosk/src/analytics/analytics_manager.dart';
@@ -25,7 +24,6 @@ class NotificationBasedMicroblinkScanner extends StatefulWidget {
 class _NotificationBasedMicroblinkScannerState extends State<NotificationBasedMicroblinkScanner> {
   late final IList<CountryDto> _countries;
   final _microblinkNotificationsBloc = MicroblinkNotificationBloc();
-  bool _acceptingResults = true;
 
   @override
   void initState() {
@@ -35,13 +33,15 @@ class _NotificationBasedMicroblinkScannerState extends State<NotificationBasedMi
 
   CountryDto? _findCountryByCode(String code) => _countries.firstWhereOrNull((c) => c.code == code);
 
-  Future<void> _handleResult(List<RecognizerResult>? result) async {
-    if (!_acceptingResults) return;
-
-    getScannedDocument(result: result, findCountry: _findCountryByCode)?.let((scannedDocument) {
-      _acceptingResults = false;
+  Future<bool> _handleResult(List<RecognizerResult>? result) async {
+    final scannedDocument = getScannedDocument(result: result, findCountry: _findCountryByCode);
+    if (scannedDocument == null) {
+      return true; // Signal to resume scanning.
+    } else {
       widget.onDocumentScanned(scannedDocument);
-    });
+
+      return false; // Signal to prevent further scanning.
+    }
   }
 
   void _handleFirstSideScanned() {
diff --git a/kiosk/lib/src/session/presentation/microblink_document_scanner/rive_microblink_document_scanner.dart b/kiosk/lib/src/session/presentation/microblink_document_scanner/rive_microblink_document_scanner.dart
index 1f7059782..d72dcca48 100644
--- a/kiosk/lib/src/session/presentation/microblink_document_scanner/rive_microblink_document_scanner.dart
+++ b/kiosk/lib/src/session/presentation/microblink_document_scanner/rive_microblink_document_scanner.dart
@@ -1,9 +1,9 @@
-import 'package:async/async.dart';
+import 'dart:async';
+
 import 'package:blinkid_flutter/microblink_scanner.dart';
 import 'package:core/bloc.dart';
 import 'package:core/collections.dart';
 import 'package:core/connector_api.dart';
-import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:kiosk/src/analytics/analytics_event.dart';
 import 'package:kiosk/src/analytics/analytics_manager.dart';
@@ -27,9 +27,6 @@ class _RiveMicroblinkDocumentScannerState extends State<RiveMicroblinkDocumentSc
   late final IList<CountryDto> _countries;
   final _riveNotificationsBloc = AnimationsBloc();
 
-  CancelableOperation<void>? _delayedOperation;
-  bool _scanProcessingPaused = false;
-
   @override
   void initState() {
     _riveNotificationsBloc.add(const AnimationsEvent.init());
@@ -39,26 +36,26 @@ class _RiveMicroblinkDocumentScannerState extends State<RiveMicroblinkDocumentSc
 
   CountryDto? _findCountryByCode(String code) => _countries.firstWhereOrNull((c) => c.code == code);
 
-  void _handleResult(Iterable<RecognizerResult>? recognizerResults) {
-    if (_scanProcessingPaused) return;
-
-    getScannedDocument(result: recognizerResults, findCountry: _findCountryByCode)?.let((scannedDocument) {
-      _scanProcessingPaused = true;
+  Future<bool> _handleResult(Iterable<RecognizerResult>? recognizerResults) async {
+    final scannedDocument = getScannedDocument(result: recognizerResults, findCountry: _findCountryByCode);
+    if (scannedDocument == null) {
+      return true; // Signal to resume scanning.
+    } else {
       _riveNotificationsBloc.add(const AnimationsEvent.scanSucceeded());
-      _delayedOperation?.cancel();
-      _delayedOperation = CancelableOperation.fromFuture(Future<void>.delayed(const Duration(seconds: 1)))
-          .then((_) => widget.onDocumentScanned(scannedDocument));
-    });
+      await Future<void>.delayed(const Duration(seconds: 1));
+      widget.onDocumentScanned(scannedDocument);
+
+      return false; // Signal to prevent further scanning.
+    }
   }
 
   void _handleFirstSideScanned() {
-    if (_scanProcessingPaused) return;
     context.read<AnalyticsManager>().sendEvent(const AnalyticsEvent.documentScannerFirstSideScanned());
     _riveNotificationsBloc.add(const AnimationsEvent.secondSideRequested());
   }
 
   void _handleDetectionStatus(DetectionStatus status) {
-    if (status.isIgnored || _scanProcessingPaused) return;
+    if (status.isIgnored) return;
 
     context.read<AnalyticsManager>().sendEvent(AnalyticsEvent.documentScannerDetectionStatusReported(status.name));
     _riveNotificationsBloc.add(AnimationsEvent.detectionStatusUpdated(status));
@@ -66,7 +63,6 @@ class _RiveMicroblinkDocumentScannerState extends State<RiveMicroblinkDocumentSc
 
   @override
   void dispose() {
-    _delayedOperation?.cancel();
     _riveNotificationsBloc.close();
     super.dispose();
   }
diff --git a/kiosk/pubspec.lock b/kiosk/pubspec.lock
index 4834f0fc9..cf01c3bbf 100644
--- a/kiosk/pubspec.lock
+++ b/kiosk/pubspec.lock
@@ -92,11 +92,9 @@ packages:
   blinkid_flutter:
     dependency: "direct main"
     description:
-      path: BlinkID
-      ref: a3270eda4f1963d51a185ef11e45152b558a2e0e
-      resolved-ref: a3270eda4f1963d51a185ef11e45152b558a2e0e
-      url: "https://github.com/MewsSystems/blinkid-flutter.git"
-    source: git
+      path: "../../blinkid-flutter/BlinkID"
+      relative: true
+    source: path
     version: "5.20.0"
   bloc:
     dependency: transitive
diff --git a/kiosk/pubspec.yaml b/kiosk/pubspec.yaml
index bfaca92f3..740e3a5fc 100644
--- a/kiosk/pubspec.yaml
+++ b/kiosk/pubspec.yaml
@@ -10,10 +10,12 @@ dependencies:
   async: ^2.8.2
   battery_info: ^1.1.1
   blinkid_flutter:
-    git:
-      url: https://github.com/MewsSystems/blinkid-flutter.git
-      ref: a3270eda4f1963d51a185ef11e45152b558a2e0e
-      path: BlinkID
+    path:
+      ../../blinkid-flutter/BlinkID
+#    git:
+#      url: https://github.com/MewsSystems/blinkid-flutter.git
+#      ref: a3270eda4f1963d51a185ef11e45152b558a2e0e
+#      path: BlinkID
   cached_network_image: ^3.2.3
   camera: ^0.10.0+4
   core:

```

</details>

@alboiuvlad29 please, check if iOS side of the plugin suffers from the same issue.

I will add analytics to track the real usage in the other PR when dealing with the other ticket: [RND-175932](https://mews.myjetbrains.com/youtrack/issue/RND-175932/Add-Analytics-Event-for-recievement-of-a-successful-result-from-Microblink)