### PR TITLE
fix: Memory leak during scanning

### DIFF
--- a/BlinkID/android/src/main/kotlin/com/microblink/blinkid/flutter/MicroblinkScanner.kt
+++ b/BlinkID/android/src/main/kotlin/com/microblink/blinkid/flutter/MicroblinkScanner.kt
@@ -46,16 +46,18 @@ class MicroblinkScanner internal constructor(
         if (!isPaused && recognizerRunner.currentState == RecognizerRunner.State.READY) {
             imageProxy.image?.let {
                 val image = ImageBuilder.buildImageFromCamera2Image(it, Orientation.ORIENTATION_LANDSCAPE_RIGHT, null)
-                recognizerRunner.recognizeVideoImage(image, createScanResultListener(image))
+                recognizerRunner.recognizeVideoImage(image, createScanResultListener(image, imageProxy))
             }
+        } else {
+            imageProxy.close()
         }
-        imageProxy.close()
     }
 
-    private fun createScanResultListener(image: Image): ScanResultListener {
+    private fun createScanResultListener(image: Image, imageProxy: ImageProxy): ScanResultListener {
         return object : ScanResultListener {
             override fun onScanningDone(recognitionSuccessType: RecognitionSuccessType) {
                 image.dispose()
+                imageProxy.close()
                 if (recognitionSuccessType == RecognitionSuccessType.UNSUCCESSFUL) {
                     return
                 }
@@ -74,6 +76,7 @@ class MicroblinkScanner internal constructor(
 
             override fun onUnrecoverableError(throwable: Throwable) {
                 image.dispose()
+                imageProxy.close()
                 callbacks.onError(throwable)
                 recognizerRunner.resetRecognitionState()
             }

--- a/BlinkID/android/src/main/kotlin/com/microblink/blinkid/flutter/MicroblinkScanner.kt
+++ b/BlinkID/android/src/main/kotlin/com/microblink/blinkid/flutter/MicroblinkScanner.kt
@@ -11,6 +11,7 @@ import com.microblink.blinkid.entities.recognizers.Recognizer
 import com.microblink.blinkid.entities.recognizers.RecognizerBundle
 import com.microblink.blinkid.flutter.recognizers.RecognizerSerializers
 import com.microblink.blinkid.hardware.orientation.Orientation
+import com.microblink.blinkid.image.Image
 import com.microblink.blinkid.image.ImageBuilder
 import com.microblink.blinkid.intent.IntentDataTransferMode
 import com.microblink.blinkid.metadata.MetadataCallbacks
@@ -45,44 +46,41 @@ class MicroblinkScanner internal constructor(
         if (!isPaused && recognizerRunner.currentState == RecognizerRunner.State.READY) {
             imageProxy.image?.let {
                 val image = ImageBuilder.buildImageFromCamera2Image(it, Orientation.ORIENTATION_LANDSCAPE_RIGHT, null)
-                recognizerRunner.recognizeVideoImage(image, createScanResultListener(imageProxy))
+                recognizerRunner.recognizeVideoImage(image, createScanResultListener(image))
             }
-        } else {
-            imageProxy.close()
         }
+        imageProxy.close()
     }
 
-    private fun createScanResultListener(imageProxy: ImageProxy): ScanResultListener {
+    private fun createScanResultListener(image: Image): ScanResultListener {
         return object : ScanResultListener {
             override fun onScanningDone(recognitionSuccessType: RecognitionSuccessType) {
+                image.dispose()
                 if (recognitionSuccessType == RecognitionSuccessType.UNSUCCESSFUL) {
-                    imageProxy.close()
                     return
                 }
 
-                val recognizers = recognizerBundle.recognizers.clone()
+                val recognizers = recognizerBundle.recognizers
                 recognizers.forEach { recognizer ->
-                    val resultState = recognizer.result.clone().resultState
+                    val resultState = recognizer.result.resultState
                     callbacks.onScanningDone(resultState)
-                    if(resultState == Recognizer.Result.State.Valid){
+                    if (resultState == Recognizer.Result.State.Valid) {
                         isPaused = true
-                        callbacks.onScanned(recognizers)
-                        imageProxy.close()
+                        callbacks.onScanned(recognizers.clone())
                         return
                     }
                 }
-
-                imageProxy.close()
             }
 
             override fun onUnrecoverableError(throwable: Throwable) {
+                image.dispose()
                 callbacks.onError(throwable)
                 recognizerRunner.resetRecognitionState()
             }
         }
     }
 
-    fun resume(){
+    fun resume() {
         recognizerRunner.resetRecognitionState()
         isPaused = false
     }

--- a/BlinkID/lib/microblink_scanner_widget.dart
+++ b/BlinkID/lib/microblink_scanner_widget.dart
@@ -73,7 +73,6 @@ class _MicroblinkScannerWidgetState extends State<MicroblinkScannerWidget> {
   }
 
   void _createChannel(int viewId) {
-    print('Creating channel for viewId: $viewId');
     channel = MethodChannel('com.microblink.blinkid.flutter/MicroblinkScannerWidget/$viewId')
       ..setMethodCallHandler((call) async {
         if (call.method == 'onScanDone') {


### PR DESCRIPTION
Images built using ImageBuilder were not being disposed and removed from memory, yielding in a crash after some time during scanning.

Before:
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/88f46176-92de-4fe2-aa6b-9a2d923a5bea">

After:

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/28c91bb8-d4ff-409f-b526-daffb746b8a0">
